### PR TITLE
Fix imports for moved modules

### DIFF
--- a/back/src/menu_generator/application/use_cases.py
+++ b/back/src/menu_generator/application/use_cases.py
@@ -1,11 +1,15 @@
 from typing import Dict
 
-from back.src.domain.dish_request import DishRequest
-from back.src.domain.menu_request import MenuRequest
-from back.src.repository.extract_json import extract_json, compact_jsons
-from back.src.repository.gpt_text_model_client import GptTextModelClient
-from back.src.repository.prompt_injecting import prompt_injecting, prompt_injecting_menu, prompt_injecting_menu_and_day, \
-    prompt_injecting_menu_and_day_iterating
+from src.menu_generator.domain.dish_request import DishRequest
+from src.menu_generator.domain.menu_request import MenuRequest
+from src.menu_generator.repository.extract_json import extract_json, compact_jsons
+from src.menu_generator.repository.gpt_text_model_client import GptTextModelClient
+from src.menu_generator.repository.prompt_injecting import (
+    prompt_injecting,
+    prompt_injecting_menu,
+    prompt_injecting_menu_and_day,
+    prompt_injecting_menu_and_day_iterating,
+)
 from config import PROMPT_SHOPPING_LIST, PROMPT_MAKE_MENU, DAY_LIST, PROMPT_MAKE_MENU_FOR_DAY, \
     PROMPT_MAKE_MENU_FOR_DAY_ITERATING
 

--- a/back/src/menu_generator/endpoints/handlers.py
+++ b/back/src/menu_generator/endpoints/handlers.py
@@ -1,11 +1,15 @@
 from fastapi import FastAPI
 
-from back.src.domain.menu_request import MenuRequest
+from src.menu_generator.domain.menu_request import MenuRequest
 from config import MODEL_NAME
-from back.src.application.use_cases import generate_shopping_list_use_case, generate_menu_use_case, \
-    generate_menu_use_case_many_calls, generate_menu_use_case_iterating
-from back.src.domain.dish_request import DishRequest
-from back.src.repository.gpt_text_model_client import GptTextModelClient
+from src.menu_generator.application.use_cases import (
+    generate_shopping_list_use_case,
+    generate_menu_use_case,
+    generate_menu_use_case_many_calls,
+    generate_menu_use_case_iterating,
+)
+from src.menu_generator.domain.dish_request import DishRequest
+from src.menu_generator.repository.gpt_text_model_client import GptTextModelClient
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)

--- a/back/src/menu_generator/repository/gpt_text_model_client.py
+++ b/back/src/menu_generator/repository/gpt_text_model_client.py
@@ -11,7 +11,7 @@ load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 
-from back.src.domain.text_model_client import TextModelClient
+from src.menu_generator.domain.text_model_client import TextModelClient
 
 
 class GptTextModelClient(TextModelClient):

--- a/back/src/menu_generator/repository/prompt_injecting.py
+++ b/back/src/menu_generator/repository/prompt_injecting.py
@@ -1,4 +1,4 @@
-from back.src.domain.menu_request import MenuRequest
+from src.menu_generator.domain.menu_request import MenuRequest
 
 
 def prompt_injecting(content: str, prompt: str):

--- a/back/test/e2e/test_generate_menu_use_case_many_calls.py
+++ b/back/test/e2e/test_generate_menu_use_case_many_calls.py
@@ -1,5 +1,5 @@
-from back.src.domain.menu_request import MenuRequest
-from back.src.endpoints.handlers import generate_menu_many_calls
+from src.menu_generator.domain.menu_request import MenuRequest
+from src.menu_generator.endpoints.handlers import generate_menu_many_calls
 
 
 def test_generate_menu_many_calls():

--- a/back/test/e2e/test_generate_shopping_list.py
+++ b/back/test/e2e/test_generate_shopping_list.py
@@ -1,5 +1,5 @@
-from src.domain.dish_request import DishRequest
-from src.endpoints.handlers import generate_shopping_list
+from src.menu_generator.domain.dish_request import DishRequest
+from src.menu_generator.endpoints.handlers import generate_shopping_list
 
 
 def test_generate_shopping_list():

--- a/back/test/integration/test_text_model_client.py
+++ b/back/test/integration/test_text_model_client.py
@@ -1,6 +1,6 @@
 from http.client import responses
 
-from src.repository.gpt_text_model_client import GptTextModelClient
+from src.menu_generator.repository.gpt_text_model_client import GptTextModelClient
 
 
 def test_gpt_text_model_client():

--- a/back/test/unit/test_promtp_injection.py
+++ b/back/test/unit/test_promtp_injection.py
@@ -1,5 +1,5 @@
-from src.domain.dish_request import DishRequest
-from src.repository.prompt_injecting import prompt_injecting
+from src.menu_generator.domain.dish_request import DishRequest
+from src.menu_generator.repository.prompt_injecting import prompt_injecting
 
 
 def test_prompt_injection():


### PR DESCRIPTION
## Summary
- update imports under `src/menu_generator`
- adapt tests to new package path

## Testing
- `PYTHONPATH=back pytest -q` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_684c364b28b8832bae0bcb3b6dae5d99