### PR TITLE
Fix alternative dish replacement

### DIFF
--- a/front/app/menu-test/page.js
+++ b/front/app/menu-test/page.js
@@ -217,6 +217,8 @@ export default function MenuPage() {
           toggleIngredientes={toggleIngredientes}
           realizadas={realizadas}
           toggleRealizada={toggleRealizada}
+          setDias={setDias}
+          guardarDiasEnLocalStorage={guardarDiasEnLocalStorage}
         />
 
         <SubirPlatoDesdeImagen

--- a/front/components/MenuCards.js
+++ b/front/components/MenuCards.js
@@ -51,6 +51,8 @@ export default function MenuCards({
   seleccionarPlato,
   realizadas,
   toggleRealizada,
+  setDias,
+  guardarDiasEnLocalStorage,
 }) {
   const [recetasGeneradas,  setRecetasGeneradas]   = useState({});
   const [openRecetas,       setOpenRecetas]        = useState({});
@@ -277,9 +279,14 @@ export default function MenuCards({
                                 {alt.map((op,i)=>(
                                   <li
                                     key={i}
-                                    onClick={()=>{
-                                      seleccionarPlato(key, i);
-                                      setOpenAlternativas(prev=>({...prev,[subKey]:false}));
+                                    onClick={() => {
+                                      setDias(prev => {
+                                        const copia = [...prev];
+                                        copia[diaActivo].comidas[momento][idx] = reemplazarEntrada(op);
+                                        guardarDiasEnLocalStorage(copia);
+                                        return copia;
+                                      });
+                                      setOpenAlternativas(prev => ({...prev, [subKey]: false}));
                                     }}
                                     className="flex items-center justify-between px-4 py-3 hover:bg-emerald-50 cursor-pointer"
                                   >


### PR DESCRIPTION
## Summary
- allow MenuCards to modify diet days when selecting alternative dish
- wire up MenuPage to pass setDias and localStorage helper

## Testing
- `npm install`
- `npm run lint`
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68503de42b68832b8e974bb2fb9cacb8