### PR TITLE
Add user metrics step for menu generator

### DIFF
--- a/front/app/page.js
+++ b/front/app/page.js
@@ -8,11 +8,13 @@ import ObjetivoSelect from "@/components/ObjetivoSelect";
 import AlergiasCheckbox from "@/components/AlergiasCheckbox";
 import DietasRadio from "@/components/DietasRadio";
 import ComidasToggle from "@/components/ComidasToggle";
+import UserMetricsWizard from "@/components/UserMetricsWizard";
 
 export default function Home() {
   const router = useRouter();
 
   // Estados principales
+  const [stage, setStage] = useState("intro");
   const [showForm, setShowForm] = useState(false);
   const [objetivo, setObjetivo] = useState("");
   const [objetivoOtro, setObjetivoOtro] = useState("");
@@ -23,6 +25,14 @@ export default function Home() {
   const [dietaOtra, setDietaOtra] = useState("");
   const [noGusta, setNoGusta] = useState("");
   const [comidasSeleccionadas, setComidasSeleccionadas] = useState([]);
+
+  const [userMetrics, setUserMetrics] = useState({
+    sexo: "",
+    edad: "",
+    altura_cm: "",
+    peso_kg: "",
+    nivel_actividad: "",
+  });
 
   // ✅ Nuevos estados
   const [postreComida, setPostreComida] = useState(true);
@@ -67,8 +77,9 @@ export default function Home() {
 
     const tiene = (momento) => comidasSeleccionadas.includes(momento);
 
-    const payload = {
+  const payload = {
       menu_goal: objetivoFinal,
+      user_metrics: userMetrics,
       meals: comidasSeleccionadas,
       allergies: alergias.length > 0 ? alergias : [""],
       diet: dietaFinal || "",
@@ -121,13 +132,23 @@ export default function Home() {
         {!showForm && (
           <button
             className="bg-emerald-500 text-white text-xl px-12 py-4 rounded-2xl shadow-lg hover:bg-emerald-600 hover:scale-105 active:scale-95 transition-all cursor-pointer font-semibold tracking-wide"
-            onClick={() => setShowForm(true)}
+            onClick={() => {
+              setShowForm(true);
+              setStage("metrics");
+            }}
           >
             Crear una dieta
           </button>
         )}
 
-        {showForm && (
+        {showForm && stage === "metrics" && (
+          <UserMetricsWizard onComplete={(data) => {
+            setUserMetrics(data);
+            setStage("form");
+          }} />
+        )}
+
+        {showForm && stage === "form" && (
           <form
             className="flex flex-col gap-6 w-full max-w-2xl py-4 mx-auto animate-fade-in"
             onSubmit={handleSubmit}

--- a/front/components/UserMetricsWizard.js
+++ b/front/components/UserMetricsWizard.js
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { sexos, nivelesActividad } from "@/data/options";
+
+export default function UserMetricsWizard({ onComplete }) {
+  const [step, setStep] = useState(0);
+  const [metrics, setMetrics] = useState({
+    sexo: "",
+    edad: "",
+    altura_cm: "",
+    peso_kg: "",
+    nivel_actividad: "",
+  });
+
+  const handleChange = (key) => (e) => {
+    setMetrics({ ...metrics, [key]: e.target.value });
+  };
+
+  const next = () => {
+    if (step >= preguntas.length - 1) {
+      onComplete(metrics);
+    } else {
+      setStep(step + 1);
+    }
+  };
+
+  const preguntas = [
+    {
+      key: "sexo",
+      label: "¿Cuál es tu sexo?",
+      input: (
+        <select
+          className="mt-4 w-full px-4 py-3 rounded-lg border border-emerald-200 focus:ring-2 focus:ring-emerald-400 outline-none transition"
+          value={metrics.sexo}
+          onChange={handleChange("sexo")}
+        >
+          <option value="" disabled>Selecciona</option>
+          {sexos.map(s => (
+            <option key={s} value={s.toLowerCase()}>{s}</option>
+          ))}
+        </select>
+      ),
+    },
+    {
+      key: "edad",
+      label: "¿Cuál es tu edad?",
+      input: (
+        <input
+          type="number"
+          className="mt-4 w-full px-4 py-3 rounded-lg border border-emerald-200 focus:ring-2 focus:ring-emerald-400 outline-none transition"
+          value={metrics.edad}
+          onChange={handleChange("edad")}
+        />
+      ),
+    },
+    {
+      key: "altura_cm",
+      label: "¿Cuál es tu altura en cm?",
+      input: (
+        <input
+          type="number"
+          className="mt-4 w-full px-4 py-3 rounded-lg border border-emerald-200 focus:ring-2 focus:ring-emerald-400 outline-none transition"
+          value={metrics.altura_cm}
+          onChange={handleChange("altura_cm")}
+        />
+      ),
+    },
+    {
+      key: "peso_kg",
+      label: "¿Cuál es tu peso en kg?",
+      input: (
+        <input
+          type="number"
+          className="mt-4 w-full px-4 py-3 rounded-lg border border-emerald-200 focus:ring-2 focus:ring-emerald-400 outline-none transition"
+          value={metrics.peso_kg}
+          onChange={handleChange("peso_kg")}
+        />
+      ),
+    },
+    {
+      key: "nivel_actividad",
+      label: "¿Cuál es tu nivel de actividad física?",
+      input: (
+        <select
+          className="mt-4 w-full px-4 py-3 rounded-lg border border-emerald-200 focus:ring-2 focus:ring-emerald-400 outline-none transition"
+          value={metrics.nivel_actividad}
+          onChange={handleChange("nivel_actividad")}
+        >
+          <option value="" disabled>Selecciona</option>
+          {nivelesActividad.map(n => (
+            <option key={n} value={n.toLowerCase()}>{n}</option>
+          ))}
+        </select>
+      ),
+    },
+  ];
+
+  const pregunta = preguntas[step];
+
+  return (
+    <div className="w-full max-w-md flex flex-col items-center gap-6 animate-fade-in">
+      <h2 className="text-2xl font-bold text-emerald-600 text-center">
+        {pregunta.label}
+      </h2>
+      {pregunta.input}
+      <div className="flex justify-between items-center w-full mt-4">
+        <span className="text-sm text-gray-500">Paso {step + 1} de {preguntas.length}</span>
+        <button
+          type="button"
+          onClick={next}
+          className="bg-emerald-600 text-white font-semibold px-6 py-2 rounded-xl shadow hover:bg-emerald-700 active:scale-95 transition"
+        >
+          {step >= preguntas.length - 1 ? "Continuar" : "Siguiente"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/front/data/options.js
+++ b/front/data/options.js
@@ -34,3 +34,12 @@ export const comidas = [
   "Merienda",
   "Cena",
 ];
+
+export const sexos = ["Hombre", "Mujer", "Otro"];
+
+export const nivelesActividad = [
+  "Sedentario",
+  "Ligero",
+  "Moderado",
+  "Intenso",
+];


### PR DESCRIPTION
## Summary
- collect new user metrics before showing the main diet form
- implement `UserMetricsWizard` component to gather the information
- send `user_metrics` to the backend when creating the menu
- extend options with lists for sexes and activity levels

## Testing
- `PYTHONPATH=. pytest -q` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_68506295f16c832b8e21fe0409b64468