### PR TITLE
Fix menu configuration modal

### DIFF
--- a/front/app/page.js
+++ b/front/app/page.js
@@ -34,9 +34,11 @@ export default function Home() {
     nivel_actividad: "",
   });
 
-  // ✅ Nuevos estados
+  // Configuración de comidas
   const [postreComida, setPostreComida] = useState(true);
   const [postreCena, setPostreCena] = useState(false);
+  const [platosComida, setPlatosComida] = useState(1);
+  const [platosCena, setPlatosCena] = useState(1);
 
   const handleAlergiaChange = (item) => {
     setAlergiasSeleccionadas(prev =>
@@ -52,6 +54,16 @@ export default function Home() {
         ? prev.filter(c => c !== item)
         : [...prev, item]
     );
+  };
+
+  const handleConfigChange = ({ item, platos, postre }) => {
+    if (item === "Comida") {
+      setPlatosComida(platos);
+      setPostreComida(postre);
+    } else if (item === "Cena") {
+      setPlatosCena(platos);
+      setPostreCena(postre);
+    }
   };
 
   const handleSubmit = async (e) => {
@@ -84,9 +96,9 @@ export default function Home() {
       allergies: alergias.length > 0 ? alergias : [""],
       diet: dietaFinal || "",
       not_rich_foods: notRichFoods.length > 0 ? notRichFoods : [""],
-      numero_de_platos_comida: tiene("Comida") ? 2 : 0,
+      numero_de_platos_comida: tiene("Comida") ? platosComida : 0,
       postre_comida: postreComida ? "si" : "no",
-      numero_de_platos_cena: tiene("Cena") ? 1 : 0,
+      numero_de_platos_cena: tiene("Cena") ? platosCena : 0,
       postre_cena: postreCena ? "si" : "no",
     };
 
@@ -186,32 +198,12 @@ export default function Home() {
             <ComidasToggle
               seleccionadas={comidasSeleccionadas}
               onToggle={handleComidasChange}
+              onConfigChange={handleConfigChange}
+              values={{
+                Comida: { platos: platosComida, postre: postreComida },
+                Cena: { platos: platosCena, postre: postreCena },
+              }}
             />
-
-            {/* ✅ NUEVOS CHECKBOXES para postres */}
-            {comidasSeleccionadas.includes("Comida") && (
-              <label className="flex items-center gap-2 text-sm text-gray-700">
-                <input
-                  type="checkbox"
-                  checked={postreComida}
-                  onChange={e => setPostreComida(e.target.checked)}
-                  className="accent-emerald-600"
-                />
-                ¿Quieres postre en la comida?
-              </label>
-            )}
-            {comidasSeleccionadas.includes("Cena") && (
-              <label className="flex items-center gap-2 text-sm text-gray-700">
-                <input
-                  type="checkbox"
-                  checked={postreCena}
-                  onChange={e => setPostreCena(e.target.checked)}
-                  className="accent-emerald-600"
-                />
-                ¿Quieres postre en la cena?
-              </label>
-            )}
-
             <button
               type="submit"
               className="mt-2 bg-emerald-600 text-white font-bold py-3 rounded-xl hover:bg-emerald-700 active:scale-95 transition-all shadow-lg"

--- a/front/components/ComidasToggle.js
+++ b/front/components/ComidasToggle.js
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { comidas } from "@/data/options";
 
-export default function ComidasToggle({ seleccionadas, onToggle }) {
+export default function ComidasToggle({ seleccionadas, onToggle, onConfigChange, values = {} }) {
   const [configOpen, setConfigOpen] = useState(null); // "Comida" o "Cena" o null
   const [platosPorComida, setPlatosPorComida] = useState({});
   const [postrePorComida, setPostrePorComida] = useState({});
@@ -23,8 +23,31 @@ export default function ComidasToggle({ seleccionadas, onToggle }) {
 
   const handlePostre = (item, quierePostre) => {
     setPostrePorComida(prev => ({ ...prev, [item]: quierePostre }));
+  };
+
+  const guardarConfig = () => {
+    if (onConfigChange && configOpen) {
+      onConfigChange({
+        item: configOpen,
+        platos: platosPorComida[configOpen] || 1,
+        postre: !!postrePorComida[configOpen],
+      });
+    }
     setConfigOpen(null);
   };
+
+  useEffect(() => {
+    if (configOpen && values[configOpen]) {
+      setPlatosPorComida(prev => ({
+        ...prev,
+        [configOpen]: values[configOpen].platos,
+      }));
+      setPostrePorComida(prev => ({
+        ...prev,
+        [configOpen]: values[configOpen].postre,
+      }));
+    }
+  }, [configOpen]);
 
   const closeModal = () => setConfigOpen(null);
 
@@ -114,7 +137,7 @@ export default function ComidasToggle({ seleccionadas, onToggle }) {
       <div className="flex justify-center">
         <button
           type="button"
-          onClick={() => setConfigOpen(null)}
+          onClick={guardarConfig}
           className="mt-1 bg-emerald-500 hover:bg-emerald-600 text-white px-5 py-2 rounded-xl text-sm font-semibold shadow"
         >
           Guardar


### PR DESCRIPTION
## Summary
- prevent ComidasToggle modal from closing when choosing the dessert option
- add callback to save configuration and restore selections when reopened
- store number of dishes and dessert choice in main form
- remove obsolete dessert checkboxes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68518192d6a0832b9f5fa6c03ff341b3