### PR TITLE
Update menu front-end for new objectives schema

### DIFF
--- a/front/app/menu-test/page.js
+++ b/front/app/menu-test/page.js
@@ -24,10 +24,6 @@ export default function MenuPage() {
   }); 
   const [dias, setDias] = useState([]);
 
-  const [objetivoProteina, setObjetivoProteina] = useState(0);
-  const [objetivoHidratos, setObjetivoHidratos] = useState(0);
-  const [objetivoGrasas, setObjetivoGrasas] = useState(0);
-  const [objetivoCalorias, setObjetivoCalorias] = useState(0);
 
   useEffect(() => {
     const stored = localStorage.getItem("dietaSemana");
@@ -36,10 +32,6 @@ export default function MenuPage() {
       console.log("📥 Recuperado de localStorage:", dietaSemana);
       console.log("📥 dietaSemana.dias:", dietaSemana.dias);
       setDias(dietaSemana.dias || []);
-      setObjetivoProteina(dietaSemana.objetivo_proteinas || 0);
-      setObjetivoHidratos(dietaSemana.objetivo_hidratos || 0);
-      setObjetivoGrasas(dietaSemana.objetivo_grasas || 0);
-      setObjetivoCalorias(dietaSemana.objetivo_calorias || 0);
     } else {
       console.error("❌ No se encontró 'dietaSemana' en localStorage");    }
   }, []);
@@ -169,6 +161,11 @@ export default function MenuPage() {
 
     return { calorias: cal, proteinas: prot, hidratos: hidr, grasas: grasa };
   })();
+
+  const objetivoCalorias = dias[diaActivo]?.objetivo_calorias || 0;
+  const objetivoProteina = dias[diaActivo]?.objetivo_proteinas || 0;
+  const objetivoHidratos = dias[diaActivo]?.objetivo_hidratos || 0;
+  const objetivoGrasas   = dias[diaActivo]?.objetivo_grasas   || 0;
 
   const kcalRestantes = Math.max(objetivoCalorias - macrosRealizadas.calorias, 0);
   const protRestantes = Math.max(objetivoProteina - macrosRealizadas.proteinas, 0);


### PR DESCRIPTION
## Summary
- adjust parsing of menu data to handle daily objectives
- calculate calorie and macronutrient targets per active day

## Testing
- `PYTHONPATH=back pytest -q` *(fails: OpenAI API key missing)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a616ce20832baea02b0917f9df75