### PR TITLE
Improve visual wizard steps

### DIFF
--- a/front/components/AlergiasCheckbox.js
+++ b/front/components/AlergiasCheckbox.js
@@ -10,29 +10,29 @@ export default function AlergiasCheckbox({
 }) {
   return (
     <div>
-      <div className="font-semibold text-gray-700 mb-2">
+      <h3 className="text-xl font-bold text-emerald-600 text-center mb-2">
         ¿Tienes alguna alergia o intolerancia alimentaria?
-      </div>
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-2 w-full">
+      </h3>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 w-full">
         {alergias.map(item => (
           <label
             key={item}
-            className={`flex items-center gap-2 px-4 py-2 rounded-xl border cursor-pointer transition select-none
-              ${seleccionadas.includes(item) ? "bg-emerald-50 border-emerald-300 font-semibold" : "bg-emerald-50/30 border-emerald-100"}
+            className={`flex flex-col items-center justify-center px-3 py-2 rounded-xl border cursor-pointer transition select-none text-center
+              ${seleccionadas.includes(item) ? "bg-emerald-500 text-white border-emerald-500" : "bg-emerald-50 border-emerald-200 text-emerald-600"}
             `}
           >
             <input
               type="checkbox"
               checked={seleccionadas.includes(item)}
               onChange={() => onToggle(item)}
-              className="accent-emerald-500 w-4 h-4"
+              className="accent-emerald-500 w-4 h-4 hidden"
             />
-            {item}
+            <span className="text-lg">{item}</span>
           </label>
         ))}
         <label
-          className={`flex items-center gap-2 px-4 py-2 rounded-xl border cursor-pointer transition select-none
-            ${mostrarOtra ? "bg-emerald-50 border-emerald-300 font-semibold" : "bg-emerald-50/30 border-emerald-100"}
+          className={`flex flex-col items-center justify-center px-3 py-2 rounded-xl border cursor-pointer transition select-none text-center col-span-2
+            ${mostrarOtra ? "bg-emerald-500 text-white border-emerald-500" : "bg-emerald-50 border-emerald-200 text-emerald-600"}
           `}
         >
           <input
@@ -42,9 +42,9 @@ export default function AlergiasCheckbox({
               setMostrarOtra(!mostrarOtra);
               if (!mostrarOtra) onOtraChange({ target: { value: "" } });
             }}
-            className="accent-emerald-500 w-4 h-4"
+            className="accent-emerald-500 w-4 h-4 hidden"
           />
-          Otra
+          <span>Otro</span>
         </label>
       </div>
       {mostrarOtra && (

--- a/front/components/ComidasToggle.js
+++ b/front/components/ComidasToggle.js
@@ -53,24 +53,31 @@ export default function ComidasToggle({ seleccionadas, onToggle, onConfigChange,
 
   return (
     <div>
-      <div className="font-semibold text-gray-700 mb-2">
+      <h3 className="text-xl font-bold text-emerald-600 text-center mb-2">
         ¿Cuántas comidas al día quieres planificar?
-      </div>
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-2 w-full">
+      </h3>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 w-full">
         {comidas.map(item => (
           <button
             key={item}
             type="button"
             onClick={() => handleClick(item)}
-            className={`
-              w-full px-4 py-2 rounded-xl border transition
+            className={`flex flex-col items-center px-3 py-2 rounded-xl border transition select-none text-center
               ${
                 seleccionadas.includes(item)
-                  ? "bg-lime-100 border-lime-400 font-semibold scale-105"
-                  : "bg-lime-50/50 border-lime-200"
-              }
-            `}
+                  ? "bg-lime-500 text-white border-lime-500"
+                  : "bg-lime-50 border-lime-200 text-lime-700"
+              }`}
           >
+            <span className="text-2xl mb-1">
+              {{
+                Desayuno: "🍳",
+                "Media mañana": "🥐",
+                Comida: "🍽️",
+                Merienda: "☕",
+                Cena: "🌙",
+              }[item]}
+            </span>
             {item}
           </button>
         ))}

--- a/front/components/DietasRadio.js
+++ b/front/components/DietasRadio.js
@@ -3,15 +3,15 @@ import { dietas } from "@/data/options";
 export default function DietasRadio({ value, onChange, otraValue, onOtraChange }) {
   return (
     <div>
-      <div className="font-semibold text-gray-700 mb-2">
+      <h3 className="text-xl font-bold text-emerald-600 text-center mb-2">
         ¿Sigues alguna dieta especial?
-      </div>
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-2 w-full">
+      </h3>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 w-full">
         {dietas.map(item => (
           <label
             key={item}
-            className={`flex items-center gap-2 px-4 py-2 rounded-xl border cursor-pointer transition select-none
-              ${value === item ? "bg-emerald-50 border-emerald-300 font-semibold" : "bg-emerald-50/30 border-emerald-100"}
+            className={`flex flex-col items-center justify-center px-3 py-2 rounded-xl border cursor-pointer transition select-none text-center
+              ${value === item ? "bg-emerald-500 text-white border-emerald-500" : "bg-emerald-50 border-emerald-200 text-emerald-600"}
             `}
           >
             <input
@@ -20,9 +20,9 @@ export default function DietasRadio({ value, onChange, otraValue, onOtraChange }
               checked={value === item}
               onClick={() => onChange(value === item ? "" : item)}
               readOnly
-              className="accent-emerald-500 w-4 h-4"
+              className="accent-emerald-500 w-4 h-4 hidden"
             />
-            {item}
+            <span className="text-lg">{item}</span>
           </label>
         ))}
       </div>

--- a/front/components/UserMetricsWizard.js
+++ b/front/components/UserMetricsWizard.js
@@ -191,7 +191,10 @@ export default function UserMetricsWizard({ onComplete }) {
             <button
               key={value}
               type="button"
-              onClick={() => setMetrics({ ...metrics, objetivo: value })}
+              onClick={() => {
+                setObjetivo(value);
+                setMetrics({ ...metrics, objetivo: value });
+              }}
               className={`flex flex-col items-center px-3 py-2 rounded-xl border transition select-none
                 ${objetivo === value ? "bg-emerald-500 text-white border-emerald-500" : "bg-emerald-50 border-emerald-200 text-emerald-600"}`}
             >
@@ -201,7 +204,10 @@ export default function UserMetricsWizard({ onComplete }) {
           ))}
           <button
             type="button"
-            onClick={() => setMetrics({ ...metrics, objetivo: value })}
+            onClick={() => {
+              setObjetivo("Otro");
+              setMetrics({ ...metrics, objetivo: "Otro" });
+            }}
             className={`flex flex-col items-center px-3 py-2 rounded-xl border transition select-none col-span-2
               ${objetivo === "Otro" ? "bg-emerald-500 text-white border-emerald-500" : "bg-emerald-50 border-emerald-200 text-emerald-600"}`}
           >

--- a/front/data/options.js
+++ b/front/data/options.js
@@ -9,22 +9,21 @@ export const objetivos = [
 ];
 
 export const alergias = [
-  "Gluten",
-  "Lactosa",
-  "Frutos secos",
-  "Mariscos",
-  "Huevo",
-  "Soja",
+  "🌾 Gluten",
+  "🥛 Lactosa",
+  "🥜 Frutos secos",
+  "🍤 Mariscos",
+  "🥚 Huevo",
+  "Otro",
 ];
 
 export const dietas = [
-  "Vegetariana",
-  "Vegana",
-  "Keto",
-  "Paleo",
-  "Sin azúcar",
-  "Sin sal",
-  "Otra",
+  "🥦 Vegana",
+  "🥗 Vegetariana",
+  "✡️ Kosher",
+  "🚫 Sin azúcar",
+  "🧂 Sin sal",
+  "Otro",
 ];
 
 export const comidas = [


### PR DESCRIPTION
## Summary
- highlight selected menu objective and update state correctly
- beautify allergy and diet steps with emoji buttons
- make meal count selection consistent with other steps
- simplify option lists with emoji icons

## Testing
- `npm run lint`
- `pytest -q` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851ade427e8832b8d99c24617ffdcdb