### PR TITLE
Add shopping list generation feature

### DIFF
--- a/front/app/lista-compra/custom/page.js
+++ b/front/app/lista-compra/custom/page.js
@@ -1,0 +1,53 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { generarListaCompra } from "@/data/generarListaCompra";
+
+export default function ListaCompraCustomPage() {
+  const router = useRouter();
+  const [diasMenu, setDiasMenu] = useState([]);
+  const [menuCompleto, setMenuCompleto] = useState(null);
+  const [seleccionados, setSeleccionados] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("dietaSemana");
+    if (stored) {
+      const data = JSON.parse(stored);
+      setDiasMenu(data.dias || []);
+      setMenuCompleto(data);
+    }
+  }, []);
+
+  const toggleDia = (nombre) => {
+    setSeleccionados(prev => prev.includes(nombre) ? prev.filter(d => d !== nombre) : [...prev, nombre]);
+  };
+
+  const handleGenerar = async () => {
+    if (!menuCompleto) return;
+    try {
+      await generarListaCompra(menuCompleto, seleccionados);
+      alert("Lista de la compra solicitada");
+    } catch (err) {
+      console.error(err);
+      alert("Error generando la lista de la compra");
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gradient-to-tr from-white via-emerald-50 to-lime-100 py-8">
+      <div className="bg-white/80 rounded-3xl shadow-xl p-8 w-full max-w-sm flex flex-col gap-4 border border-emerald-100">
+        <h2 className="text-xl font-bold text-center text-emerald-600">Selecciona los días</h2>
+        <div className="flex flex-col gap-2">
+          {diasMenu.map(d => (
+            <label key={d.nombre} className="flex items-center gap-2 text-emerald-800 bg-emerald-100 rounded-lg px-3 py-2">
+              <input type="checkbox" checked={seleccionados.includes(d.nombre)} onChange={()=>toggleDia(d.nombre)} />
+              {d.nombre}
+            </label>
+          ))}
+        </div>
+        <button onClick={handleGenerar} className="mt-4 bg-emerald-500 text-white px-4 py-2 rounded-full hover:bg-emerald-600 font-semibold">Generar lista de la compra</button>
+        <button onClick={()=>router.back()} className="text-sm text-gray-500 mt-2">Volver</button>
+      </div>
+    </main>
+  );
+}

--- a/front/app/lista-compra/page.js
+++ b/front/app/lista-compra/page.js
@@ -1,0 +1,62 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { generarListaCompra } from "@/data/generarListaCompra";
+
+export default function ListaCompraPage() {
+  const router = useRouter();
+  const [diasMenu, setDiasMenu] = useState([]);
+  const [menuCompleto, setMenuCompleto] = useState(null);
+  const [opcion, setOpcion] = useState("");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("dietaSemana");
+    if (stored) {
+      const data = JSON.parse(stored);
+      setDiasMenu(data.dias || []);
+      setMenuCompleto(data);
+    }
+  }, []);
+
+  const handleGenerar = async () => {
+    if (!menuCompleto) return;
+    let dias;
+    if (opcion === "todos") {
+      dias = diasMenu.map(d => d.nombre);
+    } else if (opcion === "entre") {
+      dias = diasMenu.slice(0, 5).map(d => d.nombre);
+    } else if (opcion === "fin") {
+      dias = diasMenu.slice(5).map(d => d.nombre);
+    } else {
+      return;
+    }
+    try {
+      await generarListaCompra(menuCompleto, dias);
+      alert("Lista de la compra solicitada");
+    } catch (err) {
+      console.error(err);
+      alert("Error generando la lista de la compra");
+    }
+  };
+
+  const botonClase = (val) =>
+    `px-4 py-2 rounded-full font-semibold shadow-md ${opcion===val?"bg-emerald-600 text-white":"bg-emerald-100 text-emerald-800 hover:bg-emerald-200"}`;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gradient-to-tr from-white via-emerald-50 to-lime-100 py-8">
+      <div className="bg-white/80 rounded-3xl shadow-xl p-8 w-full max-w-sm flex flex-col gap-4 border border-emerald-100">
+        <h2 className="text-xl font-bold text-center text-emerald-600">Generar lista de la compra</h2>
+        <p className="text-center text-sm text-gray-600">¿Para qué días deseas la lista?</p>
+        <div className="flex flex-col gap-2">
+          <button className={botonClase("todos")} onClick={()=>setOpcion("todos")}>Todos</button>
+          <button className={botonClase("entre")} onClick={()=>setOpcion("entre")}>Entre semana</button>
+          <button className={botonClase("fin")} onClick={()=>setOpcion("fin")}>Fin de semana</button>
+          <button className={botonClase("custom")} onClick={()=>router.push("/lista-compra/custom")}>Personalizar</button>
+        </div>
+        {opcion && opcion!=="custom" && (
+          <button onClick={handleGenerar} className="mt-4 bg-emerald-500 text-white px-4 py-2 rounded-full hover:bg-emerald-600 font-semibold">Generar lista de la compra</button>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/front/components/SubirPlatoDesdeImagen.js
+++ b/front/components/SubirPlatoDesdeImagen.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import Link from "next/link";
 
 const MOMENTOS = ["Desayuno", "Media mañana", "Comida", "Merienda", "Cena"];
 
@@ -118,13 +119,19 @@ export default function SubirPlatoDesdeImagen({
 
   return (
     <>
-      <div className="w-full flex justify-center mt-6">
+      <div className="w-full flex justify-center mt-6 gap-4">
         <button
           onClick={() => setMostrarOpciones(true)}
           className="bg-emerald-500 text-white px-4 py-2 rounded-full hover:bg-emerald-600 font-semibold shadow-md"
         >
           {subiendo ? "Subiendo..." : "+ Añadir plato"}
         </button>
+        <Link
+          href="/lista-compra"
+          className="bg-emerald-500 text-white px-4 py-2 rounded-full hover:bg-emerald-600 font-semibold shadow-md"
+        >
+          Generar lista de la compra
+        </Link>
       </div>
 
       {mostrarOpciones && (

--- a/front/data/generarListaCompra.js
+++ b/front/data/generarListaCompra.js
@@ -1,0 +1,18 @@
+export async function generarListaCompra(menu, dias) {
+  const res = await fetch("http://127.0.0.1:8000/generate-shopping-list-from-menu", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ menu, dias }),
+  });
+
+  const text = await res.text();
+
+  try {
+    const json = JSON.parse(text);
+    if (!res.ok) throw new Error(json.message || "Error del servidor");
+    return json;
+  } catch (e) {
+    console.error("Respuesta no JSON:", text);
+    throw new Error("Error inesperado del servidor");
+  }
+}


### PR DESCRIPTION
## Summary
- add API helper to request shopping list
- add pages to choose days and generate shopping list
- add custom selection page
- place new "Generar lista de la compra" button next to "Añadir plato"

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852dfc71f18832bbfd2a705d6550729