### PR TITLE
Add shopping list result page

### DIFF
--- a/front/app/lista-compra/custom/page.js
+++ b/front/app/lista-compra/custom/page.js
@@ -25,8 +25,9 @@ export default function ListaCompraCustomPage() {
   const handleGenerar = async () => {
     if (!menuCompleto) return;
     try {
-      await generarListaCompra(menuCompleto, seleccionados);
-      alert("Lista de la compra solicitada");
+      const lista = await generarListaCompra(menuCompleto, seleccionados);
+      localStorage.setItem("shoppingList", JSON.stringify(lista));
+      router.push("/lista-compra/resultado");
     } catch (err) {
       console.error(err);
       alert("Error generando la lista de la compra");

--- a/front/app/lista-compra/page.js
+++ b/front/app/lista-compra/page.js
@@ -31,8 +31,9 @@ export default function ListaCompraPage() {
       return;
     }
     try {
-      await generarListaCompra(menuCompleto, dias);
-      alert("Lista de la compra solicitada");
+      const lista = await generarListaCompra(menuCompleto, dias);
+      localStorage.setItem("shoppingList", JSON.stringify(lista));
+      router.push("/lista-compra/resultado");
     } catch (err) {
       console.error(err);
       alert("Error generando la lista de la compra");

--- a/front/app/lista-compra/resultado/page.js
+++ b/front/app/lista-compra/resultado/page.js
@@ -1,0 +1,38 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function ListaCompraResultado() {
+  const router = useRouter();
+  const [lista, setLista] = useState("");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("shoppingList");
+    if (stored) {
+      try {
+        const data = JSON.parse(stored);
+        setLista(data.shopping_list || "");
+      } catch {
+        setLista(stored);
+      }
+    }
+  }, []);
+
+  if (!lista) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-tr from-white via-emerald-50 to-lime-100">
+        <p className="text-center text-gray-500">Cargando lista de la compra...</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-gradient-to-tr from-white via-emerald-50 to-lime-100 py-8">
+      <div className="bg-white/80 rounded-3xl shadow-xl p-8 w-full max-w-lg flex flex-col gap-4 border border-emerald-100">
+        <h2 className="text-xl font-bold text-center text-emerald-600">Tu lista de la compra</h2>
+        <pre className="whitespace-pre-wrap text-sm text-gray-700">{lista}</pre>
+        <button onClick={() => router.push("/menu-test")} className="mt-2 bg-emerald-500 text-white px-4 py-2 rounded-full hover:bg-emerald-600 font-semibold">Volver al menú</button>
+      </div>
+    </main>
+  );
+}

--- a/front/data/generarListaCompra.js
+++ b/front/data/generarListaCompra.js
@@ -1,8 +1,11 @@
 export async function generarListaCompra(menu, dias) {
+  const filtroDias = menu?.dias?.filter((d) => dias.includes(d.nombre)) || [];
+  const payload = { week_menu: { ...menu, dias: filtroDias } };
+
   const res = await fetch("http://127.0.0.1:8000/generate-shopping-list", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ menu, dias }),
+    body: JSON.stringify(payload),
   });
 
   const text = await res.text();


### PR DESCRIPTION
## Summary
- filter selected days and POST as `week_menu`
- navigate to a result page showing the shopping list

## Testing
- `npm run lint`
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6854309cf254832b93ea50df941f38ee