### PR TITLE
Fix excess progress display

### DIFF
--- a/front/components/MacroCard.js
+++ b/front/components/MacroCard.js
@@ -1,8 +1,21 @@
 import ProgresoCircular from "./ProgresoCircular";
 
-const excesoColor = "#9333ea"; // El mismo color que el stroke de la barra
+// Color usado para los excesos. Cambia este valor si quieres otro tono.
+// Algunos ejemplos que suelen funcionar bien:
+//  - "#9333ea" (morado)
+//  - "#dc2626" (rojo)
+//  - "#2563eb" (azul)
+const excesoColorDefault = "#9333ea";
 
-export default function MacroCard({ cantidad, macro, icon, color, objetivo, realizado }) {
+export default function MacroCard({
+  cantidad,
+  macro,
+  icon,
+  color,
+  objetivo,
+  realizado,
+  excesoColor = excesoColorDefault,
+}) {
   const progreso = objetivo
     ? realizado <= objetivo
       ? realizado / objetivo
@@ -45,6 +58,7 @@ export default function MacroCard({ cantidad, macro, icon, color, objetivo, real
         size={56}
         icon={icon}
         color={color}
+        excesoColor={excesoColor}
       />
       <div className="text-xs text-gray-300 mt-1">
         Objetivo: {objetivo}{macro === "Calorías" ? "kcal" : "g"}

--- a/front/components/ProgresoCircular.js
+++ b/front/components/ProgresoCircular.js
@@ -66,7 +66,7 @@ export default function ProgresoCircular({
             stroke={excesoColor}
             strokeWidth={stroke}
             strokeDasharray={circ * Math.min(exceso, 1) + "," + circ}
-            strokeDashoffset={circ * (1 - Math.min(progreso + exceso, 1))}
+            strokeDashoffset={circ * (1 - Math.min(progreso, 1))}
             strokeLinecap="round"
             style={{ transition: "stroke-dashoffset 0.7s cubic-bezier(.42,0,.58,1)" }}
           />


### PR DESCRIPTION
## Summary
- support custom excess color in `MacroCard`
- draw smooth continuation for excess in `ProgresoCircular`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68558eba3ff4832b86464c4fc7cadb5a