### PR TITLE
Show negative macro overflow

### DIFF
--- a/front/app/menu-test/page.js
+++ b/front/app/menu-test/page.js
@@ -166,10 +166,10 @@ export default function MenuPage() {
   const objetivoHidratos = dias[diaActivo]?.objetivo_hidratos || 0;
   const objetivoGrasas   = dias[diaActivo]?.objetivo_grasas   || 0;
 
-  const kcalRestantes = Math.max(objetivoCalorias - macrosRealizadas.calorias, 0);
-  const protRestantes = Math.max(objetivoProteina - macrosRealizadas.proteinas, 0);
-  const hidrRestantes = Math.max(objetivoHidratos - macrosRealizadas.hidratos, 0);
-  const grasaRestantes = Math.max(objetivoGrasas - macrosRealizadas.grasas, 0);
+  const kcalRestantes = objetivoCalorias - macrosRealizadas.calorias;
+  const protRestantes = objetivoProteina - macrosRealizadas.proteinas;
+  const hidrRestantes = objetivoHidratos - macrosRealizadas.hidratos;
+  const grasaRestantes = objetivoGrasas - macrosRealizadas.grasas;
 
   console.log("📦 Estado de dias:", dias);
   console.log("📦 Longitud de dias:", dias?.length);

--- a/front/components/MacroCard.js
+++ b/front/components/MacroCard.js
@@ -3,7 +3,9 @@ import ProgresoCircular from "./ProgresoCircular";
 
 
 export default function MacroCard({ cantidad, macro, icon, color, objetivo, realizado }) {
-  const progreso = objetivo ? Math.min(realizado / objetivo, 1) : 0;
+  const progresoBruto = objetivo ? realizado / objetivo : 0;
+  const progreso = progresoBruto;
+  const circleColor = progresoBruto > 1 ? '#DC2626' : color;
   // Texto de subtítulo adaptado
   const subtitle =
     macro === "Calorías"
@@ -26,7 +28,7 @@ export default function MacroCard({ cantidad, macro, icon, color, objetivo, real
       <div className="text-xs text-gray-400 font-medium mb-1">
         {subtitle}
       </div>
-      <ProgresoCircular progreso={progreso} size={56} icon={icon} color={color} />
+        <ProgresoCircular progreso={progreso} size={56} icon={icon} color={circleColor} />
       <div className="text-xs text-gray-300 mt-1">
         Objetivo: {objetivo}{macro === "Calorías" ? "kcal" : "g"}
       </div>


### PR DESCRIPTION
## Summary
- show overshoot for macros in menu page
- allow circular progress indicator to exceed 100% and turn red when macros are exceeded

## Testing
- `PYTHONPATH=back pytest -q` *(fails: ModuleNotFoundError)*
- `cd front && npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685593b21b2c832b874c14391b51d82b